### PR TITLE
Allow for configuring the helper class

### DIFF
--- a/pipelineTests/groovy/testSupport/PipelineSpockTestBase.groovy
+++ b/pipelineTests/groovy/testSupport/PipelineSpockTestBase.groovy
@@ -14,6 +14,19 @@ class PipelineSpockTestBase extends Specification  implements RegressionTest {
     @Delegate PipelineTestHelper pipelineTestHelper
 
     /**
+     * Values that can be configured in configureSetup() and passed onto the @Delegate PipelineTestHelper
+     */
+    String[] scriptRoots
+    String scriptExtension
+    Map<String, String> imports
+    String baseScriptRoot
+
+    /**
+     * Configure the @Delegate PipelineTestHelper after creatation and before setUp() is callled
+     */
+    def configureSetup() {}
+
+    /**
      * Do the common setup
      */
     def setup() {
@@ -23,6 +36,22 @@ class PipelineSpockTestBase extends Specification  implements RegressionTest {
 
         // Create and config the helper
         pipelineTestHelper = new PipelineTestHelper()
-        pipelineTestHelper.setUp()
+        def helper = pipelineTestHelper.getHelper()
+        helper.with {
+            this.scriptRoots = it.scriptRoots
+            this.scriptExtension = it.scriptExtension
+            this.imports = it.imports
+            this.baseScriptRoot = it.baseScriptRoot
+            return it
+        }
+        configureSetup()
+        helper.with {
+            it.scriptRoots = this.scriptRoots
+            it.scriptExtension = this.scriptExtension
+            it.imports += this.imports
+            it.baseScriptRoot = this.baseScriptRoot
+            return it
+        }
+        setUp()
     }
 }


### PR DESCRIPTION
Your sample project doesn't allow for overriding scriptRoots, scriptExtension, import, or baseScriptRoot field values from a test class.  This adds a configureSetup() method to override that allows setting of these values after PipelineTestHelper has been created but before setUp() has been called on it.